### PR TITLE
curl: enable --compressed to decode gzipped data

### DIFF
--- a/CH-fetch_keys.sh
+++ b/CH-fetch_keys.sh
@@ -33,6 +33,7 @@ fi
 
 FN="$DATA_DIR/CH-$TAG-keylist.jwt"
 curl -X GET -s -S \
+     --compressed \
      -H 'Accept: application/json+jws' \
      -H 'Accept-Encoding: gzip' \
      -H 'Authorization: Bearer 0795dc8b-d8d0-4313-abf2-510b12d50939' \
@@ -46,6 +47,7 @@ echo "----> $FN"
 
 FN="$DATA_DIR/CH-$TAG-updates.jwt"
 curl -X GET -s -S \
+     --compressed \
      -H 'Accept: application/json+jws' \
      -H 'Accept-Encoding: gzip' \
      -H 'Authorization: Bearer 0795dc8b-d8d0-4313-abf2-510b12d50939' \


### PR DESCRIPTION
The server (newly/recently?) started delivering gzip-encoded data.
curl defaults to not decompressing data, so we need to add the
--compressed flag, otherwise we unexpectedly end up with binary data.